### PR TITLE
Make recipe remainders stay in the holograms

### DIFF
--- a/src/main/kotlin/spatialcrafting/crafter/CrafterCrafting.kt
+++ b/src/main/kotlin/spatialcrafting/crafter/CrafterCrafting.kt
@@ -125,7 +125,8 @@ private fun CrafterMultiblock.finishCraft(world: World,
 
 
     for (hologram in multiblock.getHologramEntities(world)) {
-        hologram.extractItem()
+        val ingredient = hologram.extractItem()
+        ingredient.item.recipeRemainder?.let { hologram.insertItem(ItemStack(it), multiblock) }
     }
 
 }


### PR DESCRIPTION
Tested with Bee Merry's 2x and 3x crafters (peppermint/garland) and crafting garland pedestals + beehives.